### PR TITLE
Return normalised auth details from default implementation of verify_access_token

### DIFF
--- a/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
+++ b/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
@@ -236,8 +236,9 @@ sub _verify_access_token {
                     if !$self->_has_scope( $scope, $self->refresh_tokens->{ $a_token }{ scope } );
             }
         }
+        my $details = $self->_normalize_auth_details( $self->refresh_tokens->{ $a_token } );
 
-        return ( $self->refresh_tokens->{ $a_token }{ client_id }, undef );
+        return ( $details, undef );
     }
     elsif ( exists( $self->access_tokens->{ $a_token } ) ) {
 
@@ -253,8 +254,8 @@ sub _verify_access_token {
             }
 
         }
-
-        return ( $self->access_tokens->{ $a_token }{ client_id }, undef );
+        my $details = $self->_normalize_auth_details( $self->access_tokens->{ $a_token } );
+        return ( $details, undef );
     }
 
     return ( 0, 'invalid_grant' );
@@ -295,10 +296,31 @@ sub _verify_access_token_jwt {
             }
         }
 
-        return ( $access_token_payload->{client}, undef, $access_token_payload->{scopes} );
+        return ( $self->_normalize_auth_details( $access_token_payload ), undef, $access_token_payload->{scopes} );
     }
 
     return ( 0, 'invalid_grant' );
+}
+
+# be explicit in the keys of the auth details hash returned to the client
+# this also takes into account some known differences in keys, eg
+#   scope => scopes, client => client_id, user_id ? (not available without jwt)
+
+sub _normalize_auth_details {
+  my ( $self, $auth_orig ) = @_;
+
+  my %auth_details = (
+    client_id => exists $auth_orig->{client_id} ? $auth_orig->{client_id} : $auth_orig->{client},
+    scopes    => exists $auth_orig->{scopes}    ? $auth_orig->{scopes}    : $auth_orig->{scope},
+    user_id   => exists $auth_orig->{user_id}   ? $auth_orig->{user_id}   : undef,
+  );
+
+  for my $key ( qw/ jti aud type / ) {
+    next unless exists $auth_orig->{$key};
+    $auth_details{ $key } = $auth_orig->{$key};
+  }
+
+  return \%auth_details;
 }
 
 sub _revoke_access_token {

--- a/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
+++ b/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
@@ -318,10 +318,11 @@ sub _normalize_auth_details {
   );
 
   my %auth_details;
-  for my $key ( keys %key_mapping ) {
+  KEY: for my $key ( keys %key_mapping ) {
     for my $dest_key ( @{ $key_mapping{$key} } ) {
       if ( exists $auth_orig->{ $dest_key } ) {
         $auth_details{ $key } = $auth_orig->{ $dest_key };
+        next KEY;
       }
     }
   }

--- a/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
+++ b/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
@@ -314,7 +314,7 @@ sub _normalize_auth_details {
     client  => [ 'client', 'client_id' ],
     scopes  => [ 'scopes', 'scope' ],
     user_id => [ 'user_id' ],
-    map { ($_ => [ $_ ]) } qw/ jti aud type /, # more? less?
+    map { ($_ => [ $_ ]) } qw/ jti aud type iat exp /, # more? less?
   );
 
   my %auth_details;

--- a/t/net/oauth2/authorizationserver/passwordgrant_tests.pm
+++ b/t/net/oauth2/authorizationserver/passwordgrant_tests.pm
@@ -128,8 +128,8 @@ sub run_tests {
 	my %expected_details_core = (
 	  # not available in default token without jwt
 		# user_id => 'test_user',
-		client_id => 'test_client',
-		scopes    => [ 'eat', 'sleep' ],
+		client => 'test_client',
+		scopes => [ 'eat', 'sleep' ],
 	);
 	my %got_details_core = map { ( $_ => $res->{$_} ) } keys %expected_details_core;
 	is_deeply( \%got_details_core, \%expected_details_core, 'core auth details fields look okay' );

--- a/t/net/oauth2/authorizationserver/passwordgrant_tests.pm
+++ b/t/net/oauth2/authorizationserver/passwordgrant_tests.pm
@@ -45,7 +45,7 @@ sub run_tests {
 		client_id => 'test_client',
 		scopes => [ qw/ eat sleep / ],
 	);
-	
+
 	ok( $confirmed,'confirm_by_resource_owner' );
 	ok( !$confirm_error,' ... no error' );
 	cmp_deeply( $scopes_ref,[ qw/ eat sleep / ],' ... returned scopes ref' );
@@ -122,6 +122,20 @@ sub run_tests {
 	);
 
 	ok( $res,'->verify_access_token, valid access token' );
+
+	isa_ok( $res, 'HASH', '->verify_access_token returns auth details as HASH' );
+
+	my %expected_details_core = (
+	  # not available in default token without jwt
+		# user_id => 'test_user',
+		client_id => 'test_client',
+		scopes    => [ 'eat', 'sleep' ],
+	);
+	my %got_details_core = map { ( $_ => $res->{$_} ) } keys %expected_details_core;
+	is_deeply( \%got_details_core, \%expected_details_core, 'core auth details fields look okay' );
+	is( $res->{user_id}, 'test_user', 'user_id looks okay (if specified)' )
+		if exists $res->{user_id} && $res->{user_id};
+
 	ok( ! $error,'has no error' );
 
 	( $res,$error ) = $Grant->verify_access_token(


### PR DESCRIPTION
This makes an effort to ensure that the default implementation of `_verify_access_token` returns a normalised data structure on success (see [#20 on Mojolicious::Plugin::OAuth2::Server](https://github.com/Humanstate/mojolicious-plugin-oauth2-server/issues/20)).

Note: it tries to take into account some apparent differences in keys (eg `client => client_id`, `scope => scopes`). It might be neater to try to avoid these key clashes at source (or enforce this in an object rather than hash?). However that seems like a more substantial change - this has the advantage that it does the job with minimal disruption to existing code.

I'm only adding tests here and all tests pass for me.

**HOWEVER**, this does make [`051_jwt_refresh.t`](https://github.com/Humanstate/mojolicious-plugin-oauth2-server/blob/master/t/051_jwt_refresh.t) fail on Mojolicious::Plugin::OAuth2::Server.

The returned data structure is now different ('client' is now a HashRef rather than Str) - I don't know whether this constitutes a breaking change.
