### PR TITLE
Lintian: fix interpreter path

### DIFF
--- a/examples/oauth2_client.pl
+++ b/examples/oauth2_client.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/examples/oauth2_server_db.pl
+++ b/examples/oauth2_server_db.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/examples/oauth2_server_realistic.pl
+++ b/examples/oauth2_server_realistic.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/examples/oauth2_server_simple.pl
+++ b/examples/oauth2_server_simple.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/examples/oauth2_server_simple_jwt.pl
+++ b/examples/oauth2_server_simple_jwt.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
When building a Debian package, lintian complains about the interpreter path. I have to patch it for Debian and send the patch upstream, if you don't want to merge it that's fine.