### PR TITLE
avoid returning from a Try::Tiny callback

### DIFF
--- a/lib/Net/OAuth2/AuthorizationServer/AuthorizationCodeGrant.pm
+++ b/lib/Net/OAuth2/AuthorizationServer/AuthorizationCodeGrant.pm
@@ -253,12 +253,14 @@ sub _verify_auth_code_jwt {
 
     my $auth_code_payload;
 
+    my $invalid_jwt;
     try {
         $auth_code_payload = Mojo::JWT->new( secret => $self->jwt_secret )->decode( $auth_code );
     }
     catch {
-        return ( 0, 'invalid_grant' );
+        $invalid_jwt = 1;
     };
+    return ( 0, 'invalid_grant' ) if $invalid_jwt;
 
     if (  !$auth_code_payload
         or $auth_code_payload->{ type } ne 'auth'

--- a/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
+++ b/lib/Net/OAuth2/AuthorizationServer/Defaults.pm
@@ -273,13 +273,15 @@ sub _verify_access_token_jwt {
 
     my $access_token_payload;
 
+    my $invalid_jwt;
     try {
         $access_token_payload =
             Mojo::JWT->new( secret => $self->jwt_secret )->decode( $access_token );
     }
     catch {
-        return ( 0, 'invalid_grant' );
+        $invalid_jwt = 1;
     };
+    return ( 0, 'invalid_grant' ) if $invalid_jwt;
 
     if (
         $access_token_payload


### PR DESCRIPTION
Calling return from inside a try or catch block will not return
from the function the try-catch is used.
This is a common pitfall when using Try::Tiny.

This fixes the issue raised in #20 