### PR TITLE
Remove hard dependency on Mojo::JWT

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,6 @@ WriteMakefile(
     'Time::HiRes'     => 0,
     'Carp'            => 0,
     'CryptX'          => '0.021',
-    'Mojo::JWT'       => '0.04',
     'Try::Tiny'       => '0.22',
     'Crypt::JWT'      => '0.023',
   },


### PR DESCRIPTION
The hard dependency on Mojo::JWT ends up dragging in Mojolicious… which is annoying when one wants to use this module with another framework. 🙂

It’s conceivable to declare Mojo::JWT as a test-only non-runtime dependency, if the test is supposed to always be run. But to me it doesn’t seem like the kind of test that needs to be. It seems sufficient for this test to get run during development only.